### PR TITLE
upgrade nvl to 1.2.0

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -12,8 +12,8 @@
     "@angular/compiler": "^20.1.0",
     "@angular/core": "^20.1.0",
     "@angular/platform-browser": "^20.1.0",
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/interaction-handlers": "^1.1.0",
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/interaction-handlers": "1.2.0",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.0"
   },

--- a/plain/javascript/vite/package.json
+++ b/plain/javascript/vite/package.json
@@ -9,7 +9,7 @@
     "vite": "^5.4.9"
   },
   "dependencies": {
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/interaction-handlers": "^1.1.0"
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/interaction-handlers": "1.2.0"
   }
 }

--- a/plain/javascript/webpack/package.json
+++ b/plain/javascript/webpack/package.json
@@ -15,7 +15,7 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/interaction-handlers": "^1.1.0"
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/interaction-handlers": "1.2.0"
   }
 }

--- a/plain/typescript/vite/package.json
+++ b/plain/typescript/vite/package.json
@@ -10,7 +10,7 @@
     "vite": "^5.4.9"
   },
   "dependencies": {
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/interaction-handlers": "^1.1.0"
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/interaction-handlers": "1.2.0"
   }
 }

--- a/plain/typescript/webpack/package.json
+++ b/plain/typescript/webpack/package.json
@@ -14,7 +14,7 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/interaction-handlers": "^1.1.0"
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/interaction-handlers": "1.2.0"
   }
 }

--- a/react/javascript/vite/package.json
+++ b/react/javascript/vite/package.json
@@ -9,7 +9,7 @@
     "vite": "^5.4.9"
   },
   "dependencies": {
-    "@neo4j-nvl/react": "^1.1.0",
+    "@neo4j-nvl/react": "1.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/react/javascript/webpack/package.json
+++ b/react/javascript/webpack/package.json
@@ -16,7 +16,7 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "@neo4j-nvl/react": "^1.1.0",
+    "@neo4j-nvl/react": "1.2.0",
     "process": "^0.11.10",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/react/typescript/vite/package.json
+++ b/react/typescript/vite/package.json
@@ -12,8 +12,8 @@
     "vite": "^5.4.9"
   },
   "dependencies": {
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/react": "^1.1.0",
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/react": "1.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/react/typescript/webpack/package.json
+++ b/react/typescript/webpack/package.json
@@ -16,8 +16,8 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "@neo4j-nvl/base": "^1.1.0",
-    "@neo4j-nvl/react": "^1.1.0",
+    "@neo4j-nvl/base": "1.2.0",
+    "@neo4j-nvl/react": "1.2.0",
     "process": "^0.11.10",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"


### PR DESCRIPTION
Upgrades NVL to 1.2.0. See release log here:

## [1.2.0] - 2026-05-27

This 1.2.0 release introduces a new keyboard interaction handler and SVG support for the static image wrapper React component. It also includes several performance improvements for clustering and text/icon rendering, as well as several bug fixes.

### Added
* SVG format support in the static image wrapper.
* Keyboard interaction handlers.

### Changed
* Boost performance of graph clustering for force directed layouts.
* Optimize Canvas rendering performance by caching expensive operations.
* Deprecate Cytoscape support.

### Fixed
* Fix Arabic text rendering issues to ensure characters stay connected.
* Prevent arrow ends from bouncing by removing position rounding.
* Fix issue where D3 layout would occasionally fail to display.
* Fix node position loss during a restart when the device pixel ratio changes.
* Add missing support for relationship overlay icons within the SVG renderer.
* Fix bug where reactive zoom values were not consistently applied.
* Correct the pinch-to-zoom speed scaling on the minimap.
* Add safety guards against non-finite values to prevent runtime rendering errors.
* Ensure fit targets respect `maxZoom` constraints even when omitted from `zoomOptions`.
* Force canvas repaint when icon images finish asynchronous loading.